### PR TITLE
replace plaintext password prompt with obfuscation and show censored password during confirmation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -109,11 +109,25 @@ build_command() {
         bb_url=${DEFAULT_BB_URL}
         ;;
     esac
-    read -p "Please enter your BlueBubbles password: " bb_pass
-    echo
+
+    while true; do
+        echo "Please enter your BlueBubbles password: "
+        read -s bb_pass
+        echo
+        echo "Please reenter your BlueBubbles password: "
+        read -s bb_pass_confirm
+        echo
+        if [ "${bb_pass}" != "${bb_pass_confirm}" ]; then
+            echo "Passwords do not match. Please try again."
+            echo
+        else
+            break
+        fi
+    done
+    
     echo "This is what I've got:"
     echo "BlueBubbles URL: ${bb_url}"
-    echo "BlueBubbles Password: ${bb_pass}"
+    echo "BlueBubbles Password: ${bb_pass//?/*}"
     read -r -p "Does that look correct? [Y/n] " -n 1
     case "$REPLY" in
     n | N)


### PR DESCRIPTION
This is better security practice and will prevent footguns from users reporting issues with the setup script by copying and pasting the entire output. Since the point of the plaintext was to be able to verify visually that the passwords match, let's also lean towards standard practices here by making the user simply confirm their password. The final output is also censored to adhere to the same principle, while still being relatively certain that the user entered their intended password.

Yes, the password is still ultimately stored as plaintext for the purposes of the making the command "one-shot" the startup, but that can be resolved separately, if needed.

Test
```
./setup.sh
Checking if bbctl is currently installed
bbctl found!
Re-install/update bbctl? (I honestly have no way to check if you're on latest) [Y/n] yProceeding
Finding path to bbctl
Path found! Backing up to home directory as 'bbctl.bak'
cp: : No such file or directory
Backed up! Proceeding to install
You are logged in! Checking for existing iMessage bridge
Check if bridge is running
The process must be killed to proceed. Can I do that for you? [Y/n] yFinding bridge process
Shutting down bridge
./setup.sh: line 212: kill: `': not a pid or valid job spec
Bridge has been shut down
Some updates (such as the contact fix from 2/13/24) require creating a fresh bridge. Delete bridge now? [Y/n] n
Alright, no worries
Getting OS
Getting architecture
Downloading latest executable
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
100 8920k  100 8920k    0     0  6304k      0  0:00:01  0:00:01 --:--:-- 6304k
Archive:  bbctl.zip
  inflating: bbctl-macos-arm64       
Download successful! Installing now (this may ask for your password)
Password:
Making sure bbctl works
bbctl working!
Would you like to add an alias to your shell to be able to start the bridge by simply running `start-bb-server` instead of specifying parameters each time? [Y/n] yOkie dokie, setting that up now!

Use default BlueBubbles URL 'http://localhost:1234'? (correct option for most users) [Y/n] yUsing default URL
Please enter your BlueBubbles password: 

Please reenter your BlueBubbles password: 

Passwords do not match. Please try again.

Please enter your BlueBubbles password: 

Please reenter your BlueBubbles password: 

This is what I've got:
BlueBubbles URL: http://localhost:1234
BlueBubbles Password: *********
Does that look correct? [Y/n] yGreat!
Checking for existing zshrc
Removing previous alias if it exists
Checking for Xcode command line tools
Xcode command line tools already installed
Checking macOS version
macOS version is 26.1. Good to go!
Command created! You can now start your bridge by opening a new terminal window and running the following command!
start-bb-server

Looks like we're done here! Would you like to start the bridge now? [Y/n] nAlright, sounds good! Have a nice day, and feel free to reach out to @matchstick in the iMessage bridge matrix room if you have any issues :)
```